### PR TITLE
add source server support

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="simple-targets-csx" version="5.0.0" />
+  <package id="SourceLink" version="1.1.0" />
 </packages>


### PR DESCRIPTION
fixes #298

Use [SourceLink](https://ctaggart.github.io/SourceLink/index.html) instead of GitLink, as latter does not yet support new project formats (json, xproj) but SourceLink supports individual PDBs.
Unfortunately, the need to specify `include` and `exclude` causes the `sourcelink` target to look a bit messy. Also, SourceLink does not support automatic detection of the repository URL, so this has to be hardcoded.
Target `clean` is needed because SourceLink *extends* the existing source index, potentially adding duplicate source file mappings if run multiple times on the same PDB.