### PR TITLE
add on-disk png asset to sln, removed moved .nuget/packages.config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="assets/xbehave_256x256.png" width="128" />
+<img src="assets/xbehave_128x128.png" />
 
 [![NuGet Badge](https://buildstats.info/nuget/Xbehave)](https://www.nuget.org/packages/Xbehave/)
 [![Build status](https://ci.appveyor.com/api/projects/status/2hs60yhjdoucwu7i/branch/dev?svg=true)](https://ci.appveyor.com/project/adamralph/xbehave-net/branch/dev)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="assets/xbehave_128x128.png" />
+<img src="assets/xbehave_256x256.png" width="128" />
 
 [![NuGet Badge](https://buildstats.info/nuget/Xbehave)](https://www.nuget.org/packages/Xbehave/)
 [![Build status](https://ci.appveyor.com/api/projects/status/2hs60yhjdoucwu7i/branch/dev?svg=true)](https://ci.appveyor.com/project/adamralph/xbehave-net/branch/dev)

--- a/Xbehave.sln
+++ b/Xbehave.sln
@@ -7,11 +7,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{41BB5C25
 		tests\Xbehave.Test.ruleset = tests\Xbehave.Test.ruleset
 	EndProjectSection
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{BBC5886B-9456-470B-836F-722154863920}"
-	ProjectSection(SolutionItems) = preProject
-		.nuget\packages.config = .nuget\packages.config
-	EndProjectSection
-EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{33269118-539E-4B80-8298-556253F984FE}"
 	ProjectSection(SolutionItems) = preProject
 		src\CommonAssemblyInfo.cs = src\CommonAssemblyInfo.cs
@@ -24,6 +19,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "assets", "assets", "{D254943B-777E-4CFD-8AE5-6B809EF5F3A2}"
 	ProjectSection(SolutionItems) = preProject
 		assets\xbehave_128x128.png = assets\xbehave_128x128.png
+		assets\xbehave_256x256.png = assets\xbehave_256x256.png
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{794F6FF3-998E-409C-BF91-422ABEA6BE06}"


### PR DESCRIPTION
*Edit:* Just clean-up now... the image indeed looks better in Chrome scaled 256x256 (maybe worth creating a pre-scaled sharp version?)

~~@adamralph I dared to partially revert [your change](https://github.com/xbehave/xbehave.net/commit/ef3450a6a46f3e3770e6e1072de240bde1788f8c) from 128 to 256 with width=128.~~

~~I can't find any usages of the 256x256 png (the one on [xbehave.github.io](http://xbehave.github.io/) is 356x356.), but removing seems wrong unless you have a vector file somewhere?~~