### PR TITLE
use nuspec version property explicitly

### DIFF
--- a/src/Xbehave.Core/Xbehave.Core.nuspec
+++ b/src/Xbehave.Core/Xbehave.Core.nuspec
@@ -12,7 +12,7 @@ Installing this package installs xunit.core.</description>
     <releaseNotes>https://github.com/xbehave/xbehave.net/releases</releaseNotes>
     <repository type="$RepositoryType$" url="$RepositoryUrl$" commit="$RepositoryCommit$" />
     <title>Xbehave [Core Testing Framework]</title>
-    <version>0.0.0</version>
+    <version>$Version$</version>
     <dependencies>
       <dependency id="xunit.core" version="[2.4.0, 2.5)" />
       <dependency id="xunit.extensibility.execution" version="[2.4.0, 2.5)" />

--- a/src/Xbehave.Core/Xbehave.nuspec
+++ b/src/Xbehave.Core/Xbehave.nuspec
@@ -11,7 +11,7 @@ Installing this package installs Xbehave.Core and xunit.</description>
     <projectUrl>http://xbehave.github.io/</projectUrl>
     <releaseNotes>https://github.com/xbehave/xbehave.net/releases</releaseNotes>
     <repository type="$RepositoryType$" url="$RepositoryUrl$" commit="$RepositoryCommit$" />
-    <version>0.0.0</version>
+    <version>$Version$</version>
     <dependencies>
       <dependency id="Xbehave.Core" version="[$Version$]" />
       <dependency id="xunit" version="[2.4.0, 2.5)" />


### PR DESCRIPTION
Even though it's not required to do so, since the version is used implicitly, this removes any question about why 0.0.0 is there.