### PR TITLE
rename disposable object param name

### DIFF
--- a/src/Xbehave.Core/DisposableExtensions.cs
+++ b/src/Xbehave.Core/DisposableExtensions.cs
@@ -13,16 +13,16 @@ namespace Xbehave
         /// after all steps in the current scenario have been executed.
         /// </summary>
         /// <typeparam name="T">The type of the object.</typeparam>
-        /// <param name="obj">The object to be disposed.</param>
+        /// <param name="disposable">The object to be disposed.</param>
         /// <param name="stepContext">The execution context for the current step.</param>
         /// <returns>The object.</returns>
-        public static T Using<T>(this T obj, IStepContext stepContext)
+        public static T Using<T>(this T disposable, IStepContext stepContext)
             where T : IDisposable
         {
             Guard.AgainstNullArgument(nameof(stepContext), stepContext);
 
-            stepContext.Using(obj);
-            return obj;
+            stepContext.Using(disposable);
+            return disposable;
         }
     }
 }


### PR DESCRIPTION
From

```c#
Using<T>(this T obj, IStepContext stepContext)
```
to
```c#
Using<T>(this T disposable, IStepContext stepContext)
```