### PR TITLE
remove redundant IsTestProject property

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -12,10 +12,4 @@
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
 
-  <!-- other -->
-  <PropertyGroup>
-    <IsTestProject>false</IsTestProject>
-  </PropertyGroup>
-
-
 </Project>

--- a/targets/Targets.csproj
+++ b/targets/Targets.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <IsTestProject>false</IsTestProject>
     <LangVersion>latest</LangVersion>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>

--- a/tests/Xbehave.Test/Xbehave.Test.csproj
+++ b/tests/Xbehave.Test/Xbehave.Test.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <CodeAnalysisRuleSet>Xbehave.Test.ruleset</CodeAnalysisRuleSet>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <IsTestProject>true</IsTestProject>
     <LangVersion>latest</LangVersion>
     <NoWarn>$(NoWarn);CS0168;CS1591</NoWarn>
     <RuntimeFrameworkVersion>2.0.6</RuntimeFrameworkVersion>


### PR DESCRIPTION
This was added to remove this annoying message in anticipation of https://github.com/Microsoft/vstest/issues/1866:

> Skipping running test for project {project file}. To run tests with dotnet test add "true" property to project file.

But this is not the right solution. The log level for that message should be reduced, as per https://github.com/Microsoft/vstest/pull/1867/files#r244541222

For test projects, there is no need to set this property to `true`, since that is done by `Microsoft.NET.Test.Sdk`.