### PR TITLE
Fix #595: Fail Fast on Step Nesting

### DIFF
--- a/src/Xbehave.Core/Sdk/CurrentThread.cs
+++ b/src/Xbehave.Core/Sdk/CurrentThread.cs
@@ -6,6 +6,7 @@ namespace Xbehave.Sdk
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
 
     /// <summary>
     /// Represents the currently executing thread.
@@ -16,9 +17,54 @@ namespace Xbehave.Sdk
         private static List<IStepDefinition> stepDefinitions;
 
         /// <summary>
+        /// Causes the currently executing thread to enter a step definition context
+        /// which allows step definitions to be added using <see cref="Add(IStepDefinition)"/>
+        /// and retreived using <see cref="StepDefinitions"/>.
+        /// </summary>
+        /// <returns>
+        /// An object which, when disposed, causes the currently executing thread to leave the step definition context.
+        /// </returns>
+        public static IDisposable EnterStepDefinitionContext()
+        {
+            stepDefinitions = new List<IStepDefinition>();
+
+            return new StepDefinitionContext();
+        }
+
+        /// <summary>
+        /// Add a step definition to the currently executing thread.
+        /// </summary>
+        /// <param name="item">The step definition.</param>
+        /// <exception cref="InvalidOperationException">
+        /// The currently executing thread is not in a step definition context.
+        /// </exception>
+        /// <remarks>
+        /// Before this method is called, the thread must have entered a step definiton context
+        /// with a call to <see cref="EnterStepDefinitionContext"/>.
+        /// </remarks>
+        public static void Add(IStepDefinition item)
+        {
+            if (stepDefinitions == null)
+            {
+                throw new InvalidOperationException("The currently executing thread is not in a step definition context.");
+            }
+
+            stepDefinitions.Add(item);
+        }
+
+        /// <summary>
         /// Gets the step definitions for the currently executing thread.
         /// </summary>
-        public static ICollection<IStepDefinition> StepDefinitions =>
-            stepDefinitions ?? (stepDefinitions = new List<IStepDefinition>());
+        /// <remarks>
+        /// If the currently executing thread is not in a step definition context,
+        /// the <see cref="IEnumerable{T}"/> will be empty.
+        /// </remarks>
+        public static IEnumerable<IStepDefinition> StepDefinitions =>
+            stepDefinitions ?? Enumerable.Empty<IStepDefinition>();
+
+        private sealed class StepDefinitionContext : IDisposable
+        {
+            public void Dispose() => stepDefinitions = null;
+        }
     }
 }

--- a/src/Xbehave.Core/StringExtensions.cs
+++ b/src/Xbehave.Core/StringExtensions.cs
@@ -37,7 +37,7 @@ namespace Xbehave
                         },
             };
 
-            CurrentThread.StepDefinitions.Add(stepDefinition);
+            CurrentThread.Add(stepDefinition);
             return stepDefinition;
         }
 
@@ -64,7 +64,7 @@ namespace Xbehave
                         },
             };
 
-            CurrentThread.StepDefinitions.Add(stepDefinition);
+            CurrentThread.Add(stepDefinition);
             return stepDefinition;
         }
 
@@ -85,7 +85,7 @@ namespace Xbehave
                 Body = body == null ? default(Func<IStepContext, Task>) : c => body(),
             };
 
-            CurrentThread.StepDefinitions.Add(stepDefinition);
+            CurrentThread.Add(stepDefinition);
             return stepDefinition;
         }
 
@@ -101,7 +101,7 @@ namespace Xbehave
         public static IStepBuilder x(this string text, Func<IStepContext, Task> body)
         {
             var stepDefinition = new StepDefinition { Text = text, Body = body, };
-            CurrentThread.StepDefinitions.Add(stepDefinition);
+            CurrentThread.Add(stepDefinition);
             return stepDefinition;
         }
     }

--- a/src/Xbehave.Execution/ScenarioInvoker.cs
+++ b/src/Xbehave.Execution/ScenarioInvoker.cs
@@ -157,7 +157,7 @@ namespace Xbehave.Execution
             var scenarioStepDefinitions = new List<IStepDefinition>();
             await this.aggregator.RunAsync(async () =>
             {
-                try
+                using (CurrentThread.EnterStepDefinitionContext())
                 {
                     foreach (var backgroundMethod in this.scenario.TestCase.TestMethod.TestClass.Class
                         .GetMethods(false)
@@ -170,21 +170,13 @@ namespace Xbehave.Execution
 
                     backgroundStepDefinitions.AddRange(CurrentThread.StepDefinitions);
                 }
-                finally
-                {
-                    CurrentThread.StepDefinitions.Clear();
-                }
 
-                try
+                using (CurrentThread.EnterStepDefinitionContext())
                 {
                     await this.timer.AggregateAsync(() =>
                         this.scenarioMethod.InvokeAsync(scenarioClassInstance, this.scenarioMethodArguments));
 
                     scenarioStepDefinitions.AddRange(CurrentThread.StepDefinitions);
-                }
-                finally
-                {
-                    CurrentThread.StepDefinitions.Clear();
                 }
             });
 

--- a/tests/Xbehave.Test/ScenarioFeature.cs
+++ b/tests/Xbehave.Test/ScenarioFeature.cs
@@ -234,6 +234,22 @@ namespace Xbehave.Test
             "Given a null body"
                 .x(default(Action<IStepContext>));
 
+        [Scenario]
+        public void NestedStep(Type feature, ITestResultMessage[] results)
+        {
+            "Given a scenario with a nested step"
+                .x(() => feature = typeof(ScenarioWithANestedStep));
+
+            "When I run the scenario"
+                .x(() => results = this.Run<ITestResultMessage>(feature));
+
+            "Then there should be one result"
+                .x(() => results.Length.Should().Be(1));
+
+            "And the result should be a fail"
+                .x(() => results.Single().Should().BeAssignableTo<ITestFailed>());
+        }
+
         private class FeatureWithAScenarioWithThreeSteps
         {
             [Scenario]
@@ -356,6 +372,15 @@ namespace Xbehave.Test
             [Scenario]
             public void Scenario()
             {
+            }
+        }
+
+        private class ScenarioWithANestedStep
+        {
+            [Scenario]
+            public void Scenario()
+            {
+                "Given something".x(() => "With something nested".x(() => { }));
             }
         }
     }


### PR DESCRIPTION
This fixes ~#595~ #617.

When outside of collection phase (defined by `ScenarioInvoker.InvokeScenarioMethodAsync`), throws an `InvalidOperationException` on read or write access to the collection accessed via `CurrentThread.StepDefinitions`.
Accessing the property itself doesn't throw, but access methods/properties on the collection does.

When the client code is storing a reference to the collection for later use, and that use is after collection phase, using the collection will throw.

### Breaking Changes

It's now not possible anymore to add steps before collection phase has started.
An example that doesn't work anymore:

    public class static Foo
    {
         static Foo()
         {
             "Must start first test with this".x(() => {});
         }
     }