### PR TITLE
add Style class

### DIFF
--- a/src/Xbehave.Core/Style.cs
+++ b/src/Xbehave.Core/Style.cs
@@ -1,0 +1,46 @@
+namespace Xbehave
+{
+    /// <summary>
+    /// A simple class to follow BDD style.
+    /// </summary>
+    public static class Style
+    {
+#pragma warning disable CA1062 // Validate arguments of public methods
+        /// <summary>
+        /// The Given part describes the state of the world before you begin the behavior you're specifying in this scenario.
+        /// </summary>
+        /// <param name="text">The step text.</param>
+        /// <param name="prefix">The prefix of the step text.</param>
+        /// <param name="postfix">The postfix of the step text.</param>
+        /// <returns></returns>
+        public static string Given(string text, string prefix = "Given", string postfix = "") => $"{prefix} {text.Trim()} {postfix}".Trim();
+
+        /// <summary>
+        /// The When section is that behavior that you're specifying.
+        /// </summary>
+        /// <param name="text">The step text.</param>
+        /// <param name="prefix">The prefix of the step text.</param>
+        /// <param name="postfix">The postfix of the step text.</param>
+        /// <returns></returns>
+        public static string When(string text, string prefix = "When", string postfix = "") => $"{prefix} {text.Trim()} {postfix}".Trim();
+
+        /// <summary>
+        ///  The Then section describes the changes you expect due to the specified behavior. 
+        /// </summary>
+        /// <param name="text">The step text.</param>
+        /// <param name="prefix">The prefix of the step text.</param>
+        /// <param name="postfix">The postfix of the step text.</param>
+        /// <returns></returns>
+        public static string Then(string text, string prefix = "Then", string postfix = "") => $"{prefix} {text.Trim()} {postfix}".Trim();
+
+        /// <summary>
+        /// The And helps to use behaviours together.
+        /// </summary>
+        /// <param name="text">The step text.</param>
+        /// <param name="prefix">The prefix of the step text.</param>
+        /// <param name="postfix">The postfix of the step text.</param>
+        /// <returns></returns>
+        public static string And(string text, string prefix = "And", string postfix = "") => $"{prefix} {text.Trim()} {postfix}".Trim();
+#pragma warning restore CA1062 // Validate arguments of public methods
+    }
+}


### PR DESCRIPTION
I added a very simple `Style` class to write _probably_ more readable and familiar BDD style.

```cs
using static Xbehave.Style; // Static using

namespace Widgets.Features
{
    using FluentAssertions;
    using Xbehave;

    // In order to build complicated widgets
    // As a widget builder
    // I want a calculator for performing basic arithmetic
    public class CalculatorFeature
    {
        [Scenario]
        public void Addition(int x, int y, Calculator calculator, int answer)
        {
            // NOTE: This method should only contain step definitions.
            // It doesn't make sense to write any code outside them.
            // (See the note below under "Steps".)


            Given("The number 1")
                .x(() => x = 1);

            And("The number 2")
                .x(() => y = 2);

            And("A calculator")
                .x(() => calculator = new Calculator());

            When("I add the numbers together")
                .x(() => answer = calculator.Add(x, y));

            Then("The answer is 3")
                .x(() => answer.Should().Be(3));
        }
    }
}
```

Thanks for your amazing job :)